### PR TITLE
サーバ機能実装のためのテンプレートを追加

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
-COPY main.py logic /app/
+COPY main.py /app/
+
+COPY logic/ /app/logic
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10.7-slim
+
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
+
+COPY main.py logic /app/
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,29 @@
+# Server Backend
+
+## Plan
+
+1. Add template server < DONE HERE
+2. Implement mock server
+3. Implement real logics
+
+## How to use
+
+### Install docker
+
+Follow your enviroment instruction in [this page](https://docs.docker.com/engine/install/).
+
+### Build image
+
+```
+> docker build -t shorturlext:0 . 
+```
+
+### Run image
+
+```
+> docker run -p 8080:8080 shorturlext:0  
+```
+
+### Access url
+
+http://localhost:8080/

--- a/backend/logic/thumb.py
+++ b/backend/logic/thumb.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/thumbnail")
+async def thumbnail_handler(token: str, size: int=400):
+    return {}

--- a/backend/logic/trace.py
+++ b/backend/logic/trace.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/trace")
+async def trace_handler(url: str):
+    return {}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"Hello": "World"}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI
 
+from logic import thumb, trace
+
 app = FastAPI()
 
-
-@app.get("/")
-def read_root():
-    return {"Hello": "World"}
+app.include_router(thumb.router)
+app.include_router(trace.router)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
Dockerベースでローカルサーバを立てられるようにした．
使い方は[README](https://github.com/pfpfdev/ShortUrlExt/blob/feature/server/backend/README.md)を参照のこと．

現時点では`{}`しか返さないが，以下のような情報を返すように実装予定．

### /trace

```
{
   "from_url":"http://",
   "terminated_url":"http://",
   "chains":[
      "url1",
      "url2",
      "..."
   ],
   "thumbs":{
      "200":"http://.../thumb?token=XXX&size=200",
      "400":"http://.../thumb?token=XXX&size=400",
   },
   "info":{
      "title":"aaa",
      "desciption":"bbb"
   }
}
```

### /thumbnail

画像を返す.

### /docs

FastAPIを使っているので，自動生成されたドキュメントが見える．
